### PR TITLE
chore: upgrade to NPM v12

### DIFF
--- a/.github/actions/install-npm/action.yml
+++ b/.github/actions/install-npm/action.yml
@@ -1,0 +1,14 @@
+name: Install NPM
+description: >
+  Installs the NPM version required by the `engines.npm` directive in
+  package.json, which is required for the project to build correctly.
+
+runs:
+  using: composite
+  steps:
+    - name: Install NPM
+      shell: bash
+      run: |
+        npmVersion="$(node -p 'require(`${process.env.GITHUB_WORKSPACE}/package.json`).engines.npm')"
+        echo "Installing npm@${npmVersion}"
+        npm install -g "npm@${npmVersion}"

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: "24.x"
           cache: "npm"
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
       - name: Install dependencies
         run: npm ci --no-audit
       - name: Compile

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ TypeScript.
 ## Installation
 
     npm i --save --save-exact @hello.nrfcloud.com/nrfcloud-api-helpers
+
+## Node & NPM
+
+This project requires Node.js `>=24` and npm `>=12.0.2 <13` (enforced via
+`check-node-version` on `npm install` and `npm ci`).
+
+The check is skipped during `npm publish` and `npm pack`, because
+`semantic-release` bundles its own npm (`@semantic-release/npm` depends on
+`npm@^11.6.2`) and runs the publish with that version rather than the one
+installed in CI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,13 @@
         "@types/aws-lambda": "8.10.162",
         "@types/node": "25.9.5",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
+        "check-node-version": "4.2.1",
         "commitlint": "20.5.3",
         "husky": "9.1.7"
       },
       "engines": {
         "node": ">=24",
-        "npm": ">=11"
+        "npm": ">=12.0.2 <13"
       },
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": "^3.980.0",
@@ -4661,6 +4662,110 @@
         }
       ]
     },
+    "node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-node-version": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
+      "integrity": "sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "map-values": "^1.0.1",
+        "minimist": "^1.2.0",
+        "object-filter": "^1.0.2",
+        "run-parallel": "^1.1.4",
+        "semver": "^6.3.0"
+      },
+      "bin": {
+        "check-node-version": "bin.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/check-node-version/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
@@ -6993,6 +7098,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/map-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+      "integrity": "sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ==",
+      "dev": true,
+      "license": "Public Domain"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7123,6 +7235,13 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/object-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "test": "node --no-warnings --experimental-transform-types --test \"!(node_modules|e2e-tests|integration-tests)/**/*.spec.ts\"",
-    "prepare": "husky",
+    "prepare": "husky && case \"$npm_command\" in install|ci) check-node-version --package ;; esac",
     "prepublishOnly": "node --experimental-strip-types ./.npm/compile.ts && npx tsgo -P ./.npm/tsconfig.npm.json --outDir ./npm && mv npm/src/* npm"
   },
   "repository": {
@@ -39,6 +39,7 @@
     "@types/aws-lambda": "8.10.162",
     "@types/node": "25.9.5",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "check-node-version": "4.2.1",
     "commitlint": "20.5.3",
     "husky": "9.1.7"
   },
@@ -53,7 +54,7 @@
   },
   "engines": {
     "node": ">=24",
-    "npm": ">=11"
+    "npm": ">=12.0.2 <13"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Require npm `>=12.0.2 <13` for this project (Node.js stays at `>=24`). It is enforced via
[`check-node-version`](https://www.npmjs.com/package/check-node-version) on `npm install` and `npm ci`.

## Why

npm v12 turns three code-execution paths off by default — most notably the
unauthorized execution of install scripts, which is the primary vector for
supply-chain attacks via compromised dependencies
([GitHub changelog](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/)):

- **`allowScripts` now defaults to off**, so `npm install` no longer executes
  `preinstall`, `install` or `postinstall` scripts from dependencies unless they
  are explicitly allowed in `package.json`. This also covers `prepare` scripts
  from `git`, `file` and `link` dependencies.
- **`--allow-git` now defaults to `none`**, which closes a code-execution path
  where a git dependency's `.npmrc` could override the git executable, even with
  `--ignore-scripts`.
- **`--allow-remote` now defaults to `none`**, blocking dependencies from remote
  URLs such as HTTPS tarballs.

Pinning `engines.npm` to `>=12.0.2 <13` and failing the install when it is not
met means these protections cannot be silently bypassed by running an older npm
locally or in CI.

## How

- `engines.npm` is set to `>=12.0.2 <13`. `engines.node` is left untouched.
- `check-node-version --package` runs from the `prepare` script, which npm
  executes on `npm install` and `npm ci`.
- CI installs the npm version declared in `engines.npm` through the new
  `.github/actions/install-npm` composite action, added after each
  `actions/setup-node` step.

The check is skipped during `npm publish` and `npm pack`, because `semantic-release` bundles its own npm (`@semantic-release/npm` depends on `npm@^11.6.2`) and runs the publish with that version rather than the one installed in CI.

